### PR TITLE
Update dependency on rp2040-hal to 0.7.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ws2812-pio"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "Driver implementation for the WS2812 smart LED using the RP2040's PIO peripheral."
@@ -10,7 +10,7 @@ repository = "https://github.com/rp-rs/ws2812-pio-rs/"
 [dependencies]
 embedded-hal = "0.2.5"
 fugit = "0.3.5"
-rp2040-hal = "0.6.0"
+rp2040-hal = "0.7.0"
 pio = "0.2.0"
 smart-leds-trait = "0.2.1"
 nb = "1.0.0"


### PR DESCRIPTION
Also bump crate version to 0.5.0, because changing the HAL version is a breaking change.