### PR TITLE
Upgrade to embedded-hal 1.0.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ documentation =  "https://docs.rs/ws2812-pio"
 repository = "https://github.com/rp-rs/ws2812-pio-rs/"
 
 [dependencies]
-embedded-hal = "0.2.5"
+embedded-hal = "1.0.0"
 fugit = "0.3.5"
 rp2040-hal = "0.11"
 pio = "0.2.0"


### PR DESCRIPTION
There was one breaking change that will propergate to a breaking change for end users. CountDown is no longer a trait in embedded_hal 1 and there is no replacment. There are two main paths we could take here: using the CountDown timer from rp2040-hal crate or convert to DelayNs which is what embedded_hal suggested since we only actually use it for a 60micro second delay. This does mean that you need to pass in the Timer instance rather than a CountDown instead but overall keeps the code a bit more generic and requires fewer trait bounds.

It would be nice to rename the generics from C to T as they really now represent the Timer rather than CountDown but T is already used by some iterators later on and renaming those to I conflicts with other generics - so i opted to avoid the renaming bikeshedding in this completely.